### PR TITLE
refactor scripts with env-driven paths and helpers

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,0 @@
-SS_MODELS_DIR=/vol/models
-SS_INBOX=/vol/inbox
-SS_WORK=/vol/work
-SS_OUT=/vol/out
-SS_ORT_PROVIDERS=CUDA,CPU
-SS_PARALLEL_JOBS=4

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Root directories
+SS_INBOX=/vol/inbox
+SS_WORK=/vol/work
+SS_OUT=/vol/out
+SS_MODELS_DIR=/vol/models
+SS_ASSETS_DIR=/vol/assets
+
+# RVC model paths
+SS_RVC_PTH=/vol/models/RVC/G_1234.pth
+# Optional index
+SS_RVC_INDEX=/vol/models/RVC/G_1234.index
+SS_RVC_VER=v2
+
+# Parallel jobs for batch processing
+SS_PARALLEL_JOBS=4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+.env
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+setup:
+	bash scripts/00_setup_env.sh
+
+sanity:
+	bash scripts/sanity_check.sh
+
+one:
+	bash scripts/run_one.sh $(song)
+
+batch:
+	bash scripts/run_batch.sh $(model) $(index) $(ver)
+
+backup:
+	bash scripts/90_backup_gdrive.sh

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ cp .env.example .env
 5. **跑一首 Demo**
 
 ```bash
-bash scripts/run_one.sh demo               # 等价于：python -m stepflow.cli.ssflow --manifest examples/demo.yaml
+bash scripts/run_one.sh /vol/inbox/demo.wav /vol/models/RVC/G_8200.pth
+# 或已配置 .env 后：
+bash scripts/run_one.sh demo
 ```
 
 输出：
@@ -183,7 +185,10 @@ $SS_MODELS_DIR/
 ### 极简脚本（推荐）
 
 ```
-# 单首：
+# 单首
+# 显式路径：
+./scripts/run_one.sh <input_file> <rvc_pth>
+# 使用环境变量：
 ./scripts/run_one.sh <slug>
 
 # 批量（不同歌曲并发 N 首；同一首内部严格串行）：

--- a/requirements-locked.txt
+++ b/requirements-locked.txt
@@ -1,0 +1,17 @@
+audio-separator[gpu]==0.35.2
+onnxruntime-gpu==1.19.2
+torch==2.4.0
+torchvision==0.19.0
+torchaudio==2.4.0
+numpy==1.26.4
+librosa==0.10.2.post1
+soundfile==0.12.1
+resampy==0.4.3
+pyloudnorm==0.1.1
+tqdm==4.66.4
+click==8.1.7
+python-dotenv==1.0.1
+rich==13.7.1
+jinja2==3.1.4
+pydub==0.25.1
+rvc-python==0.1.5

--- a/scripts/00_setup_env.sh
+++ b/scripts/00_setup_env.sh
@@ -1,44 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<USAGE
+Usage: bash scripts/00_setup_env.sh
+Installs system packages, python deps and prepares directories.
+USAGE
+}
+if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then usage; exit 0; fi
+
 sudo apt-get update
 sudo apt-get install -y ffmpeg git curl unzip rclone python3-venv
 
-# 进入仓库根目录（确保当前路径正确）
 cd "$(dirname "$0")/.."
 
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip wheel setuptools
 
-# ---- Python 依赖（GPU/ORT/Torch 固定版本） ----
-pip install "audio-separator[gpu]==0.35.2" \
-            onnxruntime-gpu==1.19.2 \
-            torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 \
-            --index-url https://download.pytorch.org/whl/cu121
+if [[ -f requirements-locked.txt ]]; then
+  pip install -r requirements-locked.txt --index-url https://download.pytorch.org/whl/cu121
+else
+  pip install "audio-separator[gpu]==0.35.2" \
+              onnxruntime-gpu==1.19.2 \
+              torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 \
+              --index-url https://download.pytorch.org/whl/cu121
+  pip install numpy==1.26.4 librosa==0.10.2.post1 soundfile==0.12.1 resampy==0.4.3 \
+              pyloudnorm==0.1.1 tqdm==4.66.4 click==8.1.7 python-dotenv==1.0.1 rich==13.7.1 \
+              jinja2==3.1.4 pydub==0.25.1
+  pip install rvc-python==0.1.5
+fi
 
-pip install numpy==1.26.4 librosa==0.10.2.post1 soundfile==0.12.1 resampy==0.4.3 \
-            pyloudnorm==0.1.1 tqdm==4.66.4 click==8.1.7 python-dotenv==1.0.1 rich==13.7.1 \
-            jinja2==3.1.4 pydub==0.25.1
+SS_INBOX=${SS_INBOX:-/vol/inbox}
+SS_WORK=${SS_WORK:-/vol/work}
+SS_OUT=${SS_OUT:-/vol/out}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+SS_ASSETS_DIR=${SS_ASSETS_DIR:-/vol/assets}
 
-# RVC 推理封装（从 PyPI 安装 rvc-python；若版本更新，Agent 可选同系最新稳定版）
-pip install rvc-python==0.1.5
+mkdir -p "$SS_INBOX" "$SS_WORK" "$SS_OUT" "$SS_MODELS_DIR/UVR" "$SS_MODELS_DIR/RVC" "$SS_ASSETS_DIR"
 
-# 目录就绪
-mkdir -p /vol/{inbox,work,out} /vol/models/{UVR,RVC} /vol/assets
+[ -f "$SS_ASSETS_DIR/hubert_base.pt" ] || \
+  curl -L -o "$SS_ASSETS_DIR/hubert_base.pt" https://dl.fbaipublicfiles.com/hubert/hubert_base_ls960.pt
+[ -f "$SS_ASSETS_DIR/rmvpe.onnx" ] || \
+  curl -L -o "$SS_ASSETS_DIR/rmvpe.onnx" https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/rmvpe.onnx
 
-# RVC 依赖（若不存在则下载）
-[ -f /vol/assets/hubert_base.pt ] || \
-  curl -L -o /vol/assets/hubert_base.pt https://dl.fbaipublicfiles.com/hubert/hubert_base_ls960.pt
-[ -f /vol/assets/rmvpe.onnx ] || \
-  curl -L -o /vol/assets/rmvpe.onnx https://huggingface.co/lj1995/VoiceConversionWebUI/resolve/main/rmvpe.onnx
-
-# ORT GPU Provider 自检（失败则安装 nightly 兜底）
 if ! audio-separator --env_info | grep -q "CUDAExecutionProvider"; then
-  echo "[WARN] CUDAExecutionProvider not detected. Installing ORT nightly..."
-  pip install --force-reinstall --no-cache-dir ort-nightly-gpu \
-    --index-url=https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-12-nightly/pypi/simple/
-  audio-separator --env_info
+  echo "[ERR] CUDAExecutionProvider not detected. Please check CUDA drivers/ORT installation." >&2
+  exit 1
 fi
 
 echo "[OK] setup done"

--- a/scripts/10_separate_inst.sh
+++ b/scripts/10_separate_inst.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+usage(){ cat <<USAGE
+Usage: scripts/10_separate_inst.sh <input_file> <slug>
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 source "$(dirname "$0")/../.venv/bin/activate"
 
-IN="$1"                             # 全路径，如 /vol/inbox/<slug>.wav
-SLUG="${2:-$(basename "${IN%.*}")}"
-BASE="/vol/work/${SLUG}"
-OUTDIR="/vol/out/${SLUG}"
+IN="$1"; SLUG="${2:-$(basename "${IN%.*}")}"
+SS_WORK=${SS_WORK:-/vol/work}
+SS_OUT=${SS_OUT:-/vol/out}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+
+BASE="$SS_WORK/${SLUG}"
+OUTDIR="$SS_OUT/${SLUG}"
 mkdir -p "$BASE/sep1" "$OUTDIR"
 
-MODEL_DIR="/vol/models/UVR"
+MODEL_DIR="$SS_MODELS_DIR/UVR"
 MODEL="UVR-MDX-NET-Inst_HQ_3.onnx"
 
-# 执行真实分离（输出到当前目录）
 cd "$BASE/sep1"
 audio-separator "$IN" \
   --model_filename "$MODEL" \
   --model_file_dir "$MODEL_DIR"
 
-# 规整命名
 INST=$(ls -1 *Instrumental*.wav 2>/dev/null | head -n1)
 VOX=$(ls -1 *Vocals*.wav 2>/dev/null | head -n1)
 [ -n "${INST:-}" ] && mv "$INST" "$BASE/01_accompaniment.wav"
 [ -n "${VOX:-}" ] && mv "$VOX"  "$BASE/01_vocals_mix.wav"
 
-# 守卫
 [ -f "$BASE/01_accompaniment.wav" ] || { echo "[ERR] Missing accompaniment"; exit 1; }
 [ -f "$BASE/01_vocals_mix.wav" ]  || { echo "[ERR] Missing vocals mix"; exit 1; }
 

--- a/scripts/20_extract_main.sh
+++ b/scripts/20_extract_main.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+usage(){ cat <<USAGE
+Usage: scripts/20_extract_main.sh <slug>
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 source "$(dirname "$0")/../.venv/bin/activate"
 
-SLUG="$1"; BASE="/vol/work/${SLUG}"; mkdir -p "$BASE/sep2"
+SLUG="$1"
+SS_WORK=${SS_WORK:-/vol/work}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+BASE="$SS_WORK/${SLUG}"; mkdir -p "$BASE/sep2"
 IN="$BASE/01_vocals_mix.wav"; [ -f "$IN" ] || { echo "[ERR] $IN"; exit 1; }
-MODEL_DIR="/vol/models/UVR"; MODEL="Kim_Vocal_2.onnx"
+MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Kim_Vocal_2.onnx"
 
 cd "$BASE/sep2"
 audio-separator "$IN" \

--- a/scripts/30_dereverb_denoise.sh
+++ b/scripts/30_dereverb_denoise.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+usage(){ cat <<USAGE
+Usage: scripts/30_dereverb_denoise.sh <slug>
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 source "$(dirname "$0")/../.venv/bin/activate"
 
-SLUG="$1"; BASE="/vol/work/${SLUG}"; mkdir -p "$BASE/sep3"
+SLUG="$1"
+SS_WORK=${SS_WORK:-/vol/work}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+BASE="$SS_WORK/${SLUG}"; mkdir -p "$BASE/sep3"
 IN="$BASE/02_main_vocal.wav"; [ -f "$IN" ] || { echo "[ERR] $IN"; exit 1; }
-MODEL_DIR="/vol/models/UVR"; MODEL="Reverb_HQ_By_FoxJoy.onnx"
+MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Reverb_HQ_By_FoxJoy.onnx"
 
 cd "$BASE/sep3"
 audio-separator "$IN" \

--- a/scripts/40_rvc_convert.sh
+++ b/scripts/40_rvc_convert.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+usage(){ cat <<USAGE
+Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> [index] [v1|v2]
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 source "$(dirname "$0")/../.venv/bin/activate"
 
 SLUG="$1"; RVC_PTH="$2"; RVC_INDEX="${3:-}"; RVC_VER="${4:-v2}"
-BASE="/vol/work/${SLUG}"; OUTDIR="/vol/out/${SLUG}"; mkdir -p "$OUTDIR"
+SS_WORK=${SS_WORK:-/vol/work}
+SS_OUT=${SS_OUT:-/vol/out}
+SS_ASSETS_DIR=${SS_ASSETS_DIR:-/vol/assets}
+BASE="$SS_WORK/${SLUG}"; OUTDIR="$SS_OUT/${SLUG}"; mkdir -p "$OUTDIR"
 IN="$BASE/03_main_vocal_dry.wav"; [ -f "$IN" ] || { echo "[ERR] $IN"; exit 1; }
 
-export RVC_ASSETS_DIR="/vol/assets"
+export RVC_ASSETS_DIR="$SS_ASSETS_DIR"
 
-# 调用 rvc-python 的 CLI；如该版本选项有变更，Agent 需查询 --help 并等价替换为同义参数
 python -m rvc_python cli \
   -i "$IN" \
   -o "$OUTDIR/04_vocal_converted.wav" \

--- a/scripts/50_finalize_and_report.py
+++ b/scripts/50_finalize_and_report.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
-import os, sys, json, argparse
+import os, sys, json, argparse, hashlib, time
 import numpy as np, soundfile as sf, pyloudnorm as pyln, resampy
+import onnxruntime as ort
 
 TARGET_LUFS_INST = -20.0
 TARGET_LUFS_LEAD = -18.5
-PEAK_CEIL = 10 ** (-3.0/20)   # -3 dBFS
+PEAK_CEIL = 10 ** (-3.0/20)
 OUT_SR = 48000
+
+SS_WORK = os.getenv('SS_WORK', '/vol/work')
+SS_OUT = os.getenv('SS_OUT', '/vol/out')
+SS_MODELS_DIR = os.getenv('SS_MODELS_DIR', '/vol/models')
 
 
 def read_audio_mono(path):
@@ -14,17 +19,14 @@ def read_audio_mono(path):
         x = np.mean(x, axis=1, keepdims=True)
     return x.astype(np.float32), sr
 
-
 def measure_lufs(x, sr):
     meter = pyln.Meter(sr)
     return float(meter.integrated_loudness(x.squeeze()))
-
 
 def gain_to_target_lufs(x, sr, target):
     curr = measure_lufs(x, sr)
     g = 10 ** ((target - curr)/20)
     return g, curr
-
 
 def peak_limit_pair(a, b):
     peak = max(np.max(np.abs(a)), np.max(np.abs(b)))
@@ -33,15 +35,24 @@ def peak_limit_pair(a, b):
     g = PEAK_CEIL / peak
     return a*g, b*g, True, float(peak)
 
+def sha256(path):
+    if os.path.isfile(path):
+        h = hashlib.sha256()
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(8192), b''):
+                h.update(chunk)
+        return h.hexdigest()
+    return None
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('--slug', required=True)
     args = ap.parse_args()
+    t0 = time.time()
 
     slug = args.slug
-    base = f"/vol/work/{slug}"
-    outd = f"/vol/out/{slug}"
+    base = f"{SS_WORK}/{slug}"
+    outd = f"{SS_OUT}/{slug}"
     os.makedirs(outd, exist_ok=True)
 
     inst_in = f"{base}/01_accompaniment.wav"
@@ -49,11 +60,9 @@ def main():
     inst_out = f"{outd}/{slug}.instrumental.UVR-MDX-NET-Inst_HQ_3.wav"
     lead_out = f"{outd}/{slug}.lead_converted.wav"
 
-    # 读取
     inst, sr_i = read_audio_mono(inst_in)
     lead, sr_l = read_audio_mono(lead_in)
 
-    # 重采样到 48k
     if sr_i != OUT_SR:
         inst = resampy.resample(inst.squeeze(), sr_i, OUT_SR).reshape(-1,1)
         sr_i = OUT_SR
@@ -61,20 +70,16 @@ def main():
         lead = resampy.resample(lead.squeeze(), sr_l, OUT_SR).reshape(-1,1)
         sr_l = OUT_SR
 
-    # LUFS 目标增益
     g_i, lufs_i = gain_to_target_lufs(inst, sr_i, TARGET_LUFS_INST)
     g_l, lufs_l = gain_to_target_lufs(lead, sr_l, TARGET_LUFS_LEAD)
     inst_s = inst * g_i
     lead_s = lead * g_l
 
-    # 峰值护栏：双轨同比例缩放
     inst_f, lead_f, limited, peak_before = peak_limit_pair(inst_s, lead_s)
 
-    # 写盘（24-bit PCM）
     sf.write(inst_out, inst_f, OUT_SR, subtype='PCM_24')
     sf.write(lead_out, lead_f, OUT_SR, subtype='PCM_24')
 
-    # 校验：时长漂移（以伴奏为参考）
     ref_len = len(inst_f)
     lead_len = len(lead_f)
     drift = abs(lead_len - ref_len) / max(1, ref_len)
@@ -92,18 +97,26 @@ def main():
         'length_drift_ratio': float(drift),
         'pass': (drift <= 0.005)
     }
-
     with open(f"{outd}/quality_report.json", 'w') as f:
         json.dump(report, f, indent=2)
-
     if not report['pass']:
         raise SystemExit(f"Length drift too large: {report['length_drift_ratio']}")
 
-    # 追踪信息（最小）
+    providers = ort.get_available_providers()
+    models = {
+        'uvr_sep': sha256(os.path.join(SS_MODELS_DIR,'UVR','UVR-MDX-NET-Inst_HQ_3.onnx')),
+        'uvr_main': sha256(os.path.join(SS_MODELS_DIR,'UVR','Kim_Vocal_2.onnx')),
+        'uvr_reverb': sha256(os.path.join(SS_MODELS_DIR,'UVR','Reverb_HQ_By_FoxJoy.onnx')),
+        'rvc_pth': sha256(os.getenv('SS_RVC_PTH','')),
+        'rvc_index': sha256(os.getenv('SS_RVC_INDEX',''))
+    }
     trace = {
         'slug': slug,
         'paths': {'inst_in': inst_in, 'lead_in': lead_in, 'inst_out': inst_out, 'lead_out': lead_out},
-        'env': {k: os.getenv(k) for k in ['SS_MODELS_DIR','SS_ORT_PROVIDERS']}
+        'env': {k: os.getenv(k) for k in ['SS_MODELS_DIR','SS_ORT_PROVIDERS']},
+        'providers_snapshot': providers,
+        'model_sha256': models,
+        'elapsed_sec': time.time()-t0
     }
     with open(f"{outd}/trace.json", 'w') as f:
         json.dump(trace, f, indent=2)

--- a/scripts/60_optional_mixdown.sh
+++ b/scripts/60_optional_mixdown.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SLUG="$1"; OUTDIR="/vol/out/${SLUG}"
+
+usage(){ cat <<USAGE
+Usage: scripts/60_optional_mixdown.sh <slug>
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
+SLUG="$1"
+SS_OUT=${SS_OUT:-/vol/out}
+OUTDIR="$SS_OUT/${SLUG}"
 BGM="${OUTDIR}/${SLUG}.instrumental.UVR-MDX-NET-Inst_HQ_3.wav"
 LEAD="${OUTDIR}/${SLUG}.lead_converted.wav"
 FINAL="${OUTDIR}/${SLUG}.mix_48k.wav"

--- a/scripts/90_backup_gdrive.sh
+++ b/scripts/90_backup_gdrive.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage(){ cat <<USAGE
+Usage: scripts/90_backup_gdrive.sh
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
+SS_OUT=${SS_OUT:-/vol/out}
 REMOTE_ROOT="gdrive:Seperate02/out"
 
-# 首次需已完成：rclone config 交互创建名为 gdrive 的远端（drive 类型）
-
-rclone sync /vol/out "$REMOTE_ROOT" --transfers=8 --checkers=8 --fast-list --checksum --create-empty-src-dirs
+rclone sync "$SS_OUT" "$REMOTE_ROOT" --transfers=8 --checkers=8 --fast-list --checksum --create-empty-src-dirs
 TS=$(date +%Y%m%d-%H%M%S)
-rclone copy /vol/out "gdrive:Seperate02/out-archives/${TS}" --transfers=8 --checkers=8 --fast-list --checksum --create-empty-src-dirs
+rclone copy "$SS_OUT" "gdrive:Seperate02/out-archives/${TS}" --transfers=8 --checkers=8 --fast-list --checksum --create-empty-src-dirs
 
 echo "[OK] Backup done → $REMOTE_ROOT & out-archives/${TS}"

--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -1,14 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RVC_PTH="$1"              # 共用的 RVC 模型路径
-RVC_INDEX="${2:-}"        # 可选 index
+usage(){ cat <<USAGE
+Usage: scripts/run_batch.sh <rvc_model.pth> [index] [v1|v2]
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
+RVC_PTH="${1:?rvc model required}"
+RVC_INDEX="${2:-}"
 RVC_VER="${3:-v2}"
 PARALLEL="${SS_PARALLEL_JOBS:-4}"
 
-# 遍历 /vol/inbox 下的音频文件
-find /vol/inbox -maxdepth 1 -type f \( -iname '*.wav' -o -iname '*.mp3' -o -iname '*.flac' -o -iname '*.m4a' \) | sort |
-while IFS= read -r f; do
-  slug=$(basename "${f%.*}")
-  echo "./scripts/run_one.sh \"$f\" $slug \"$RVC_PTH\" \"$RVC_INDEX\" $RVC_VER"
+SS_INBOX=${SS_INBOX:-/vol/inbox}
+SS_WORK=${SS_WORK:-/vol/work}
+
+[[ -f "$RVC_PTH" ]] || { echo "[ERR] missing RVC model $RVC_PTH" >&2; exit 1; }
+[[ -z "$RVC_INDEX" || -f "$RVC_INDEX" ]] || { echo "[ERR] bad RVC index $RVC_INDEX" >&2; exit 1; }
+
+declare -A seen
+for ext in wav flac m4a mp3; do
+  while IFS= read -r f; do
+    slug=$(basename "${f%.*}")
+    [[ -n "${seen[$slug]:-}" ]] && continue
+    seen[$slug]=1
+    echo "$f::$slug"
+  done < <(find "$SS_INBOX" -maxdepth 1 -type f -iname "*.$ext" | sort)
+done |
+while IFS='::' read -r f slug; do
+  mkdir -p "$SS_WORK/$slug"
+  echo "bash scripts/run_one.sh \"$f\" \"$RVC_PTH\" \"$RVC_INDEX\" $RVC_VER \"$slug\" >\"$SS_WORK/$slug/run.log\" 2>&1"
 done | xargs -I{} -P "$PARALLEL" bash -lc {}

--- a/scripts/run_one.sh
+++ b/scripts/run_one.sh
@@ -1,18 +1,55 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-IN="$1"            # /vol/inbox/<slug>.<ext>
-SLUG="${2:-$(basename "${IN%.*}")}"
-RVC_PTH="$3"       # /vol/models/RVC/<model>.pth
-RVC_INDEX="${4:-}"  # 可选：/vol/models/RVC/<model>.index
-RVC_VER="${5:-v2}"
+usage(){ cat <<USAGE
+Usage:
+  scripts/run_one.sh <input_file> <rvc_model.pth> [index] [v1|v2] [slug]
+  scripts/run_one.sh <slug>  # requires SS_INBOX and SS_RVC_PTH
+Examples:
+  bash scripts/run_one.sh /vol/inbox/foo.wav /vol/models/RVC/G.pth
+  bash scripts/run_one.sh foo
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
+SS_INBOX=${SS_INBOX:-/vol/inbox}
+SS_WORK=${SS_WORK:-/vol/work}
+SS_OUT=${SS_OUT:-/vol/out}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+SS_ASSETS_DIR=${SS_ASSETS_DIR:-/vol/assets}
+
+if [[ $# -ge 2 && -f "$1" ]]; then
+  IN="$1"
+  RVC_PTH="$2"
+  RVC_INDEX="${3:-}"
+  RVC_VER="${4:-v2}"
+  SLUG="${5:-$(basename "${IN%.*}")}"
+elif [[ $# -eq 1 ]]; then
+  SLUG="$1"
+  for ext in wav flac m4a mp3; do
+    if [[ -f "$SS_INBOX/$SLUG.$ext" ]]; then IN="$SS_INBOX/$SLUG.$ext"; break; fi
+  done
+  [[ -n "${IN:-}" ]] || { echo "[ERR] input $SLUG.* not found in $SS_INBOX" >&2; exit 1; }
+  RVC_PTH="${SS_RVC_PTH:?SS_RVC_PTH not set}"
+  RVC_INDEX="${SS_RVC_INDEX:-}"
+  RVC_VER="${SS_RVC_VER:-v2}"
+else
+  usage; exit 1
+fi
+
+[[ -f "$IN" ]] || { echo "[ERR] missing input $IN" >&2; exit 1; }
+[[ -f "$RVC_PTH" ]] || { echo "[ERR] missing RVC model $RVC_PTH" >&2; exit 1; }
+[[ -z "$RVC_INDEX" || -f "$RVC_INDEX" ]] || { echo "[ERR] bad RVC index $RVC_INDEX" >&2; exit 1; }
+[[ "$RVC_VER" == v1 || "$RVC_VER" == v2 ]] || { echo "[ERR] RVC version must be v1 or v2" >&2; exit 1; }
+
+export SS_RVC_PTH="$RVC_PTH" SS_RVC_INDEX="$RVC_INDEX" SS_RVC_VER="$RVC_VER"
 
 bash scripts/10_separate_inst.sh "$IN" "$SLUG"
 bash scripts/20_extract_main.sh "$SLUG"
 bash scripts/30_dereverb_denoise.sh "$SLUG"
 bash scripts/40_rvc_convert.sh "$SLUG" "$RVC_PTH" "$RVC_INDEX" "$RVC_VER"
 python scripts/50_finalize_and_report.py --slug "$SLUG"
-# 可选：
+# optional:
 # bash scripts/60_optional_mixdown.sh "$SLUG"
 
-echo "[DONE] /vol/out/${SLUG}"
+echo "[DONE] $SS_OUT/${SLUG}"

--- a/scripts/sanity_check.sh
+++ b/scripts/sanity_check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage(){ cat <<USAGE
+Usage: bash scripts/sanity_check.sh
+Checks GPU/ORT providers and directory availability.
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
+SS_INBOX=${SS_INBOX:-/vol/inbox}
+SS_WORK=${SS_WORK:-/vol/work}
+SS_OUT=${SS_OUT:-/vol/out}
+SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
+SS_ASSETS_DIR=${SS_ASSETS_DIR:-/vol/assets}
+
+command -v nvidia-smi >/dev/null && nvidia-smi || echo "[WARN] nvidia-smi not found"
+
+if command -v audio-separator >/dev/null; then
+  audio-separator --env_info || true
+else
+  echo "[WARN] audio-separator not found" >&2
+fi
+
+python - <<'PY'
+import onnxruntime as ort, json
+print('ORT providers:', json.dumps(ort.get_available_providers()))
+PY
+
+for d in "$SS_INBOX" "$SS_WORK" "$SS_OUT" "$SS_MODELS_DIR" "$SS_ASSETS_DIR"; do
+  [ -d "$d" ] || echo "[WARN] missing dir: $d"
+done
+
+echo "SS_INBOX=$SS_INBOX"; echo "SS_WORK=$SS_WORK"; echo "SS_OUT=$SS_OUT"
+echo "SS_MODELS_DIR=$SS_MODELS_DIR"; echo "SS_ASSETS_DIR=$SS_ASSETS_DIR"


### PR DESCRIPTION
## Summary
- add environment-variable based paths and argument validation across scripts
- provide setup sanity check, requirements lock file, and .env example
- update README and Makefile for new usage

## Testing
- `bash scripts/sanity_check.sh 2>&1 | head -n 50`
- `bash scripts/run_one.sh -h`
- `bash scripts/run_batch.sh -h`
- `bash scripts/00_setup_env.sh -h`
- `bash scripts/10_separate_inst.sh -h`
- `bash scripts/20_extract_main.sh -h`
- `bash scripts/30_dereverb_denoise.sh -h`
- `bash scripts/40_rvc_convert.sh -h`
- `bash scripts/60_optional_mixdown.sh -h`
- `bash scripts/90_backup_gdrive.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_689ce693425083309bb1251c8df4e7d8