### PR TITLE
chore: split env setup and index tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ SS_OUT=/vol/out
 SS_MODELS_DIR=/vol/models
 SS_ASSETS_DIR=/vol/assets
 
+SS_UVR_VENV=/opt/venvs/uvr
+SS_RVC_VENV=/opt/venvs/rvc
+SS_CACHE_DIR=/vol/.cache
+HF_HOME=/vol/.cache/huggingface
+TRANSFORMERS_CACHE=/vol/.cache/huggingface
+TORCH_HOME=/vol/.cache/torch
+PIP_CACHE_DIR=/vol/.cache/pip
+
 # RVC model paths
 SS_RVC_PTH=/vol/models/RVC/G_8200.pth
 SS_RVC_INDEX=/vol/models/RVC/G_8200.index

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .RECIPEPREFIX := >
-.PHONY: help setup-lock sanity demo env one pull batch push backup
+.PHONY: help setup-lock setup-split sanity demo env one pull batch push backup doctor clean-cache index-first
 
 help:
 > @echo "Targets:"
 > @echo "  setup-lock  - install deps via lock file"
+> @echo "  setup-split - install dual venvs"
 > @echo "  sanity      - run environment checks"
 > @echo "  demo        - run demo song with fixed paths"
 > @echo "  env         - show key environment vars"
@@ -12,6 +13,9 @@ help:
 > @echo "  batch model=<pth> index=<idx> ver=<v1|v2>"
 > @echo "  push        - push processed outputs"
 > @echo "  backup      - backup outputs to gdrive"
+> @echo "  doctor      - space check"
+> @echo "  clean-cache - remove caches"
+> @echo "  index-first - build RVC index"
 
 setup-lock:
 > bash scripts/00_setup_env.sh
@@ -43,3 +47,16 @@ push:
 
 backup:
 > bash scripts/90_backup_gdrive.sh
+
+setup-split:
+> bash scripts/00_setup_env_split.sh
+
+doctor:
+> bash scripts/doctor_space.sh
+
+clean-cache:
+> bash scripts/cleanup_caches.sh
+
+index-first:
+> @echo "Use scripts/70_build_index_from_wav.py to build index:" 
+> @echo "  ${SS_RVC_VENV:-/opt/venvs/rvc}/bin/python scripts/70_build_index_from_wav.py --wav <in.wav> --out <out.index>"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ Seperate02/
 
 ## 快速开始（Quick Start）
 
+### 低空间环境建议
+
+```bash
+make doctor
+make clean-cache
+```
+
 下面示例以 Linux/Mac 为例；Windows 可使用 WSL。
 
 1. **克隆仓库并安装依赖**
@@ -100,7 +107,7 @@ Seperate02/
 ```bash
 git clone https://github.com/FusinKoo/Seperate02.git
 cd Seperate02
-bash scripts/00_setup_env.sh    # 生成虚拟环境并安装依赖
+make setup-split                # 生成双虚拟环境并安装依赖
 ```
 
 2. **配置环境变量**
@@ -135,6 +142,8 @@ bash scripts/run_batch.sh /vol/models/RVC/G_8200.pth /vol/models/RVC/G_8200.inde
 ---
 
 ## 环境与依赖
+
+该项目使用 UVR 与 RVC 双虚拟环境，分别锁定 NumPy 2 与 NumPy 1.23，以避免依赖冲突。
 
 - **操作系统**：Linux / macOS（Apple Silicon 可用 CPU 跑通，建议 GPU 环境）
 - **Python**：3.10+（建议 3.10/3.11）
@@ -172,6 +181,13 @@ UVR 使用 `audio-separator 0.35.2`，参数映射：`--chunk`=分块大小、`-
 ---
 
 ## 运行入口
+
+### Index 先行剧本
+
+1. 上传清洁的人声 WAV 至 `inbox`
+2. 生成 Index：`${SS_RVC_VENV:-/opt/venvs/rvc}/bin/python scripts/70_build_index_from_wav.py --wav /vol/inbox/my_voice_clean.wav --out /vol/models/RVC/G_8200.index`
+3. 使用 `rclone copy` 将生成的 `.index` 回传
+
 
 ### 极简脚本（推荐）
 

--- a/requirements-rvc.txt
+++ b/requirements-rvc.txt
@@ -1,0 +1,2 @@
+numpy==1.23.5
+rvc-python==0.1.5

--- a/requirements-uvr.txt
+++ b/requirements-uvr.txt
@@ -1,0 +1,7 @@
+audio-separator[gpu]==0.35.2
+onnxruntime-gpu==1.19.2
+numpy==2.0.2
+librosa==0.10.2.post1
+resampy==0.4.3
+soundfile==0.12.1
+pyloudnorm==0.1.1

--- a/scripts/00_setup_env_split.sh
+++ b/scripts/00_setup_env_split.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+retry() {
+  local n=0
+  until "$@"; do
+    n=$((n+1))
+    if [ "$n" -ge 2 ]; then
+      return 1
+    fi
+    echo "[WARN] retry $n for: $*" >&2
+    sleep 1
+  done
+}
+
+UVR=${SS_UVR_VENV:-/opt/venvs/uvr}
+RVC=${SS_RVC_VENV:-/opt/venvs/rvc}
+CACHE_DIR=${SS_CACHE_DIR:-/vol/.cache}
+mkdir -p "$UVR" "$RVC" "$CACHE_DIR"
+
+export HF_HOME="$CACHE_DIR/huggingface"
+export TRANSFORMERS_CACHE="$CACHE_DIR/huggingface"
+export TORCH_HOME="$CACHE_DIR/torch"
+export PIP_CACHE_DIR="$CACHE_DIR/pip"
+
+try python3 -m venv "$UVR" && "$UVR/bin/pip" install -U pip wheel setuptools
+try "$UVR/bin/pip" install --no-cache-dir -r requirements-uvr.txt
+try python3 -m venv "$RVC" && "$RVC/bin/pip" install -U pip wheel setuptools
+try "$RVC/bin/pip" install --no-cache-dir \
+  torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 \
+  --index-url https://download.pytorch.org/whl/cu124
+try "$RVC/bin/pip" install --no-cache-dir -r requirements-rvc.txt
+"$UVR/bin/pip" cache purge || true; "$RVC/bin/pip" cache purge || true
+
+if command -v df >/dev/null; then
+  df -h "$UVR" "$RVC" "$CACHE_DIR" /vol 2>/dev/null || df -h
+fi
+
+echo "[INFO] UVR venv: $UVR"
+echo "[INFO] RVC venv: $RVC"
+echo "[HINT] export PATH=\"$UVR/bin:$RVC/bin:\$PATH\""
+
+which "$UVR/bin/audio-separator" || true
+which "$RVC/bin/rvc" || true

--- a/scripts/10_separate_inst.sh
+++ b/scripts/10_separate_inst.sh
@@ -9,13 +9,17 @@ fi
 # shellcheck source=env.sh
 source "$SCRIPT_DIR/env.sh"
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 usage(){ cat <<USAGE
 Usage: scripts/10_separate_inst.sh <input_file> <slug>
 USAGE
 }
 [[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
 
-source "$SCRIPT_DIR/../.venv/bin/activate"
 
 IN="$1"; SLUG="${2:-$(basename "${IN%.*}")}" 
 BASE="$SS_WORK/${SLUG}"
@@ -28,7 +32,7 @@ DEVICE_OPT=""
 [[ "${SS_FORCE_CPU:-0}" == 1 ]] && DEVICE_OPT="--device cpu"
 
 cd "$BASE/sep1"
-audio-separator "$IN" \
+"$SS_UVR_VENV/bin/audio-separator" "$IN" \
   --model_filename "$MODEL" \
   --model_file_dir "$MODEL_DIR" \
   --chunk 10 --overlap 5 --fade_overlap hann \

--- a/scripts/20_extract_main.sh
+++ b/scripts/20_extract_main.sh
@@ -9,13 +9,17 @@ fi
 # shellcheck source=env.sh
 source "$SCRIPT_DIR/env.sh"
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 usage(){ cat <<USAGE
 Usage: scripts/20_extract_main.sh <slug>
 USAGE
 }
 [[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
 
-source "$SCRIPT_DIR/../.venv/bin/activate"
 
 SLUG="$1"
 BASE="$SS_WORK/${SLUG}"; mkdir -p "$BASE/sep2"
@@ -25,7 +29,7 @@ DEVICE_OPT=""
 [[ "${SS_FORCE_CPU:-0}" == 1 ]] && DEVICE_OPT="--device cpu"
 
 cd "$BASE/sep2"
-audio-separator "$IN" \
+"$SS_UVR_VENV/bin/audio-separator" "$IN" \
   --model_filename "$MODEL" \
   --model_file_dir "$MODEL_DIR" \
   --chunk 8 --overlap 4 --fade_overlap hann \

--- a/scripts/30_dereverb_denoise.sh
+++ b/scripts/30_dereverb_denoise.sh
@@ -9,13 +9,17 @@ fi
 # shellcheck source=env.sh
 source "$SCRIPT_DIR/env.sh"
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 usage(){ cat <<USAGE
 Usage: scripts/30_dereverb_denoise.sh <slug>
 USAGE
 }
 [[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
 
-source "$SCRIPT_DIR/../.venv/bin/activate"
 
 SLUG="$1"
 BASE="$SS_WORK/${SLUG}"; mkdir -p "$BASE/sep3"
@@ -25,7 +29,7 @@ DEVICE_OPT=""
 [[ "${SS_FORCE_CPU:-0}" == 1 ]] && DEVICE_OPT="--device cpu"
 
 cd "$BASE/sep3"
-audio-separator "$IN" \
+"$SS_UVR_VENV/bin/audio-separator" "$IN" \
   --model_filename "$MODEL" \
   --model_file_dir "$MODEL_DIR" \
   --chunk 8 --overlap 4 --fade_overlap hann \

--- a/scripts/40_rvc_convert.sh
+++ b/scripts/40_rvc_convert.sh
@@ -9,13 +9,18 @@ fi
 # shellcheck source=env.sh
 source "$SCRIPT_DIR/env.sh"
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+command -v "$SS_RVC_VENV/bin/rvc" >/dev/null || { echo "[ERR] rvc not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 usage(){ cat <<USAGE
 Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> <rvc.index> [v1|v2]
 USAGE
 }
 [[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
 
-source "$SCRIPT_DIR/../.venv/bin/activate"
 
 SLUG="$1"; RVC_PTH="$2"; RVC_INDEX="$3"; RVC_VER="${4:-v2}"
 BASE="$SS_WORK/${SLUG}"; OUTDIR="$SS_OUT/${SLUG}"; mkdir -p "$OUTDIR"
@@ -27,7 +32,7 @@ IN="$BASE/03_main_vocal_dry.wav"; [ -f "$IN" ] || { echo "[ERR] $IN"; exit 1; }
 
 export RVC_ASSETS_DIR="$SS_ASSETS_DIR"
 
-python -m rvc_python cli \
+"$SS_RVC_VENV/bin/rvc" infer \
   -i "$IN" \
   -o "$OUTDIR/04_vocal_converted.wav" \
   -mp "$RVC_PTH" \

--- a/scripts/70_build_index_from_wav.py
+++ b/scripts/70_build_index_from_wav.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import argparse, os, sys
+
+
+def check_deps():
+    missing = []
+    for m in ["transformers", "librosa", "soundfile", "faiss"]:
+        try:
+            __import__(m)
+        except Exception:
+            missing.append(m)
+    if missing:
+        pip = f"{os.getenv('SS_RVC_VENV', '/opt/venvs/rvc')}/bin/pip"
+        print(f"[ERR] missing deps: {', '.join(missing)}", file=sys.stderr)
+        print(f"[ERR] run `{pip} install --no-cache-dir faiss-cpu transformers librosa soundfile`", file=sys.stderr)
+        sys.exit(1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build FAISS index from WAV")
+    ap.add_argument("--wav", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    check_deps()
+    import librosa, faiss, numpy as np, torch
+    from transformers import HubertModel, HubertProcessor
+
+    wav, _ = librosa.load(args.wav, sr=16000, mono=True)
+    processor = HubertProcessor.from_pretrained("facebook/hubert-base-ls960")
+    model = HubertModel.from_pretrained("facebook/hubert-base-ls960", use_safetensors=True)
+    with torch.no_grad():
+        inp = processor(wav, sampling_rate=16000, return_tensors="pt")
+        emb = model(**inp).last_hidden_state.squeeze(0).cpu().numpy().astype("float32")
+
+    index = faiss.IndexFlatL2(emb.shape[1])
+    index.add(emb)
+    faiss.write_index(index, args.out)
+    print(f"[OK] index saved to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_caches.sh
+++ b/scripts/cleanup_caches.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_DIR=${SS_CACHE_DIR:-/vol/.cache}
+
+echo "[BEFORE]"
+df -h / /vol "$CACHE_DIR"
+
+rm -rf "$HOME/.cache" "$CACHE_DIR/pip" "$CACHE_DIR/huggingface" "$CACHE_DIR/torch" /root/.cache/pip 2>/dev/null || true
+rm -rf /tmp/* 2>/dev/null || true
+
+echo "[AFTER]"
+df -h / /vol "$CACHE_DIR"

--- a/scripts/doctor_space.sh
+++ b/scripts/doctor_space.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_THR=5
+VOL_THR=20
+CACHE_DIR=${SS_CACHE_DIR:-/vol/.cache}
+
+check_space() {
+  local dir="$1"; local thr="$2"
+  local avail
+  avail=$(df -BG "$dir" | awk 'NR==2{gsub(/G/,"",$4); print $4}')
+  if [ "$avail" -lt "$thr" ]; then
+    echo "[ERR] $dir free ${avail}G < ${thr}G" >&2
+    du -xh "$dir" -d1 | sort -h | tail
+    exit 1
+  fi
+}
+
+df -h / /vol "$CACHE_DIR"
+check_space / "$ROOT_THR"
+check_space /vol "$VOL_THR"
+
+if command -v nvidia-smi >/dev/null; then
+  nvidia-smi --query-gpu=name,driver_version,cuda_version --format=csv,noheader | head -n1
+else
+  echo "nvidia-smi not found" >&2
+fi

--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 export LC_ALL=C.UTF-8
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 usage(){
   cat <<'USAGE'
 Usage: scripts/run_batch.sh <rvc_model.pth> <rvc.index> [v1|v2]

--- a/scripts/run_one.sh
+++ b/scripts/run_one.sh
@@ -8,6 +8,11 @@ SS_INBOX=${SS_INBOX:-/vol/inbox}
 SS_WORK=${SS_WORK:-/vol/work}
 SS_OUT=${SS_OUT:-/vol/out}
 
+: "${SS_UVR_VENV:=/opt/venvs/uvr}"; : "${SS_RVC_VENV:=/opt/venvs/rvc}"
+: "${SS_CACHE_DIR:=/vol/.cache}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+command -v "$SS_UVR_VENV/bin/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 IN=${1:-}
 RVC_PTH=${2:-${SS_RVC_PTH:-}}
 RVC_INDEX=${3:-${SS_RVC_INDEX:-}}
@@ -48,7 +53,7 @@ bash scripts/10_separate_inst.sh "$path" "$slug"
 bash scripts/20_extract_main.sh "$slug"
 bash scripts/30_dereverb_denoise.sh "$slug"
 bash scripts/40_rvc_convert.sh "$slug" "$RVC_PTH" "$RVC_INDEX" "$RVC_VER"
-python3 scripts/50_finalize_and_report.py --slug "$slug"
+"$SS_UVR_VENV/bin/python" scripts/50_finalize_and_report.py --slug "$slug"
 # 可选：
 # bash scripts/60_optional_mixdown.sh "$slug"
 


### PR DESCRIPTION
## Summary
- add separate UVR and RVC requirements with dual venv installer
- add space doctor, cache cleanup, and index builder utilities
- use venv binaries in pipeline and document low-space dual-env workflow

## Testing
- `bash -n scripts/*.sh`
- `grep -R "$SS_UVR_VENV/bin/audio-separator" scripts | wc -l`
- `grep -R "$SS_RVC_VENV/bin/rvc" scripts | wc -l`
- `rg -n "use_safetensors=True" scripts/70_build_index_from_wav.py`
- `rg -n "setup-split|doctor|clean-cache|index-first" Makefile`
- `rg -n "SS_UVR_VENV|SS_RVC_VENV|SS_CACHE_DIR|HF_HOME|TRANSFORMERS_CACHE|TORCH_HOME|PIP_CACHE_DIR" .env.example`
- `shellcheck -x -S error scripts/*.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d36e98e4c833086261f75ad77ef2b