### PR TITLE
Improve environment locking and rclone tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 > @echo "  index-first - build RVC index (make index-first wav=<in.wav> out=<out.index>)"
 
 setup-lock:
-> bash scripts/00_setup_env_split.sh
+> bash scripts/00_setup_env_split.sh --locked
 
 setup:
 > bash scripts/00_setup_env_split.sh

--- a/manifest/models_required.txt
+++ b/manifest/models_required.txt
@@ -1,0 +1,8 @@
+UVR/UVR-MDX-NET-Inst_HQ_3.onnx
+UVR/Kim_Vocal_2.onnx
+UVR/Reverb_HQ_By_FoxJoy.onnx
+RVC/G_8200.pth
+RVC/G_8200.index
+assets/hubert_base.pt
+assets/rmvpe.onnx
+

--- a/scripts/10_separate_inst.sh
+++ b/scripts/10_separate_inst.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-usage(){ echo "Usage: $0 <input_file> <slug>"; exit 2; }
-IN=${1:-}; SLUG=${2:-}; [[ -f "${IN:-}" && -n "${SLUG:-}" ]] || usage
+usage(){
+  cat <<USG
+Usage: scripts/10_separate_inst.sh <input_file> <slug>
+Example: bash scripts/10_separate_inst.sh song.wav myslug
+Env    : SS_WORK, SS_MODELS_DIR, SS_UVR_VENV
+USG
+}
+case "${1:-}" in -h|--help) usage; exit 0;; esac
+IN=${1:-}; SLUG=${2:-}; [[ -f "${IN:-}" && -n "${SLUG:-}" ]] || { usage; exit 2; }
 set +u; [ -f .env ] && . .env; set -u
 SS_WORK="${SS_WORK:-/vol/work}"; SS_MODELS_DIR="${SS_MODELS_DIR:-/vol/models}"; SS_UVR_VENV="${SS_UVR_VENV:-/vol/venvs/uvr}"
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"; MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="UVR-MDX-NET-Inst_HQ_3.onnx"

--- a/scripts/20_extract_main.sh
+++ b/scripts/20_extract_main.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-usage(){ echo "Usage: $0 <slug>"; exit 2; }
-SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || usage
+usage(){
+  cat <<USG
+Usage: scripts/20_extract_main.sh <slug>
+Example: bash scripts/20_extract_main.sh myslug
+Env    : SS_WORK, SS_MODELS_DIR, SS_UVR_VENV
+USG
+}
+case "${1:-}" in -h|--help) usage; exit 0;; esac
+SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || { usage; exit 2; }
 set +u; [ -f .env ] && . .env; set -u
 SS_WORK="${SS_WORK:-/vol/work}"; SS_MODELS_DIR="${SS_MODELS_DIR:-/vol/models}"; SS_UVR_VENV="${SS_UVR_VENV:-/vol/venvs/uvr}"
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"; MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Kim_Vocal_2.onnx"

--- a/scripts/30_dereverb_denoise.sh
+++ b/scripts/30_dereverb_denoise.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-usage(){ echo "Usage: $0 <slug>"; exit 2; }
-SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || usage
+usage(){
+  cat <<USG
+Usage: scripts/30_dereverb_denoise.sh <slug>
+Example: bash scripts/30_dereverb_denoise.sh myslug
+Env    : SS_WORK, SS_MODELS_DIR, SS_UVR_VENV
+USG
+}
+case "${1:-}" in -h|--help) usage; exit 0;; esac
+SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || { usage; exit 2; }
 set +u; [ -f .env ] && . .env; set -u
 SS_WORK="${SS_WORK:-/vol/work}"; SS_MODELS_DIR="${SS_MODELS_DIR:-/vol/models}"; SS_UVR_VENV="${SS_UVR_VENV:-/vol/venvs/uvr}"
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"; MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Reverb_HQ_By_FoxJoy.onnx"

--- a/scripts/40_rvc_convert.sh
+++ b/scripts/40_rvc_convert.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage(){ cat <<USAGE
+Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> <rvc.index> [v1|v2]
+Example: bash scripts/40_rvc_convert.sh myslug /vol/models/RVC/G_8200.pth /vol/models/RVC/G_8200.index v2
+Env   : SS_WORK, SS_OUT, SS_ASSETS_DIR, SS_UVR_VENV, SS_RVC_VENV
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ ! -f "$SCRIPT_DIR/env.sh" ]]; then
   echo "[FATAL] Missing $SCRIPT_DIR/env.sh" >&2
@@ -20,12 +28,6 @@ elif [ -x "$SS_RVC_VENV/bin/python" ]; then
 else
   echo "[ERR] rvc not found; run scripts/00_setup_env_split.sh"; exit 2;
 fi
-
-usage(){ cat <<USAGE
-Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> <rvc.index> [v1|v2]
-USAGE
-}
-[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
 
 
 SLUG="$1"; RVC_PTH="$2"; RVC_INDEX="$3"; RVC_VER="${4:-v2}"

--- a/scripts/gdrive_push_outputs.sh
+++ b/scripts/gdrive_push_outputs.sh
@@ -5,7 +5,7 @@ export LC_ALL=C.UTF-8
 
 usage(){
   cat <<'USAGE'
-Usage: scripts/gdrive_push_outputs.sh <slug>
+Usage: scripts/gdrive_push_outputs.sh [--dry-run] <slug>
 Desc : 上传 /vol/out/<slug> 至 GDrive，并按 .src 把原始输入移至 processed/ 或 failed/
 Env  : SS_OUT, SS_WORK, SS_GDRIVE_REMOTE, SS_GDRIVE_ROOT
 USAGE
@@ -18,7 +18,14 @@ ensure_vol_mount() {
   fi
 }
 
-case "${1:-}" in -h|--help) usage; exit 0;; esac
+DRY_RUN=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0;;
+    --dry-run) DRY_RUN="--dry-run"; shift;;
+    *) break;;
+  esac
+done
 ensure_vol_mount
 [[ -n "${1:-}" ]] || { usage; exit 2; }
 slug="$1"
@@ -39,8 +46,11 @@ outdir="$SS_OUT/$slug"
 [[ -d "$outdir" ]] || { echo "[ERR] missing outdir: $outdir"; exit 1; }
 
 # 上传最终产物
-RCLONE_OPTS=(--tpslimit "${SS_RCLONE_TPS:-4}" --tpslimit-burst "${SS_RCLONE_TPS:-4}" --checkers "${SS_RCLONE_CHECKERS:-4}" --transfers "${SS_RCLONE_TRANSFERS:-2}" --fast-list)
-rclone copy "$outdir" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/out/${slug}" --checksum "${RCLONE_OPTS[@]}"
+RCLONE_OPTS=(--checksum --fast-list --transfers "${SS_RCLONE_TRANSFERS:-4}" --checkers "${SS_RCLONE_CHECKERS:-8}" --drive-chunk-size "${SS_RCLONE_CHUNK:-64M}" --tpslimit "${SS_RCLONE_TPS:-4}" --tpslimit-burst "${SS_RCLONE_TPS:-4}")
+cmd=(rclone copy "$outdir" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/out/${slug}" "${RCLONE_OPTS[@]}")
+[[ -n "$DRY_RUN" ]] && cmd+=("$DRY_RUN")
+echo "+ ${cmd[*]}"
+"${cmd[@]}"
 
 # 判定成功/失败
 pass=false
@@ -50,18 +60,27 @@ fi
 
 if $pass; then
   # 移动原始文件到 processed
-  rclone moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/processed/${fname}" "${RCLONE_OPTS[@]}" || true
+  cmd=(rclone moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/processed/${fname}" "${RCLONE_OPTS[@]}")
+  [[ -n "$DRY_RUN" ]] && cmd+=("$DRY_RUN")
+  echo "+ ${cmd[*]}"
+  "${cmd[@]}" || true
   # 上传 per‑song run.log
   LOG_LOCAL="$SS_WORK/$slug/run.log"
   if [[ -f "$LOG_LOCAL" ]]; then
     TS=$(date -u +%Y%m%d)
-    rclone copyto "$LOG_LOCAL" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/logs/${TS}/${slug}_run.log" --checksum "${RCLONE_OPTS[@]}" || true
+    cmd=(rclone copyto "$LOG_LOCAL" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/logs/${TS}/${slug}_run.log" "${RCLONE_OPTS[@]}")
+    [[ -n "$DRY_RUN" ]] && cmd+=("$DRY_RUN")
+    echo "+ ${cmd[*]}"
+    "${cmd[@]}" || true
   fi
   # 清理工作目录（成功后）
   rm -rf "$SS_WORK/$slug" || true
 else
   # 失败：移动到 failed 并写原因
-  rclone moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}" "${RCLONE_OPTS[@]}" || true
+  cmd=(rclone moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}" "${RCLONE_OPTS[@]}")
+  [[ -n "$DRY_RUN" ]] && cmd+=("$DRY_RUN")
+  echo "+ ${cmd[*]}"
+  "${cmd[@]}" || true
   reason_file="/tmp/${slug}.reason.txt"
   echo "Seperate02 failure for $slug" > "$reason_file"
   [[ -f "$outdir/quality_report.json" ]] && {
@@ -73,7 +92,10 @@ else
     echo -e "\n--- run.log (tail -n 200) ---" >> "$reason_file"
     tail -n 200 "$SS_WORK/$slug/run.log" >> "$reason_file" || true
   fi
-  rclone copyto "$reason_file" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}.reason.txt" "${RCLONE_OPTS[@]}"
+  cmd=(rclone copyto "$reason_file" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}.reason.txt" "${RCLONE_OPTS[@]}")
+  [[ -n "$DRY_RUN" ]] && cmd+=("$DRY_RUN")
+  echo "+ ${cmd[*]}"
+  "${cmd[@]}"
   rm -f "$reason_file"
 fi
 


### PR DESCRIPTION
## Summary
- support `--locked` installations and wire `make setup-lock`
- add model manifest with `gdrive_sync_models.sh --check`
- add `--dry-run` to pull/push scripts and standardize rclone options
- harden final loudness checks and add `-h/--help` to core steps

## Testing
- `make setup-lock` *(fails: /vol is not mounted)*
- `bash scripts/gdrive_sync_models.sh --check` *(fails: /vol is not mounted)*
- `bash scripts/gdrive_pull_inputs.sh --dry-run` *(fails: /vol is not mounted)*
- `bash scripts/gdrive_push_outputs.sh --dry-run test` *(fails: /vol is not mounted)*
- `bash scripts/10_separate_inst.sh -h`
- `bash scripts/20_extract_main.sh -h`
- `bash scripts/30_dereverb_denoise.sh -h`
- `bash scripts/40_rvc_convert.sh -h`
- `python scripts/50_finalize_and_report.py -h`


------
https://chatgpt.com/codex/tasks/task_e_689e9cb6c14083308ed0d9407df6eaca