### PR TITLE
Use hash-locked requirements for setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help:
 > @echo "  index-first - build RVC index (make index-first wav=<in.wav> out=<out.index>)"
 
 setup-lock:
-> bash scripts/00_setup_env_split.sh
+> pip install -r requirements-locked.txt --require-hashes
 
 setup:
 > bash scripts/00_setup_env_split.sh

--- a/scripts/00_setup_env_split.sh
+++ b/scripts/00_setup_env_split.sh
@@ -27,7 +27,16 @@ ensure_vol_mount() {
   fi
 }
 
-case "${1:-}" in -h|--help) usage; exit 0;; esac
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --locked)
+    pip install -r requirements-locked.txt --require-hashes
+    exit 0
+    ;;
+esac
 ensure_vol_mount
 
 if ! command -v ffmpeg >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- install dependencies from `requirements-locked.txt` with hash verification via `make setup-lock`
- add `--locked` flag to environment setup script to use the lock file

## Testing
- `make setup-lock` *(fails: Cannot connect to proxy. No matching distribution found for audio-separator==0.35.2)*

------
https://chatgpt.com/codex/tasks/task_e_689ea096c650833084a14dbdb110448e