### PR TITLE
Add help branches and delay env checks for utility scripts

### DIFF
--- a/scripts/20_extract_main.sh
+++ b/scripts/20_extract_main.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-usage(){ echo "Usage: $0 <slug>"; exit 2; }
-SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || usage
+usage(){ echo "Usage: $0 <slug>"; }
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+SLUG=${1:-}
+[[ -n "${SLUG:-}" ]] || { usage; exit 2; }
+
 set +u; [ -f .env ] && . .env; set -u
 SS_WORK="${SS_WORK:-/vol/work}"; SS_MODELS_DIR="${SS_MODELS_DIR:-/vol/models}"; SS_UVR_VENV="${SS_UVR_VENV:-/vol/venvs/uvr}"
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"; MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Kim_Vocal_2.onnx"

--- a/scripts/30_dereverb_denoise.sh
+++ b/scripts/30_dereverb_denoise.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-usage(){ echo "Usage: $0 <slug>"; exit 2; }
-SLUG=${1:-}; [[ -n "${SLUG:-}" ]] || usage
+usage(){ echo "Usage: $0 <slug>"; }
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+SLUG=${1:-}
+[[ -n "${SLUG:-}" ]] || { usage; exit 2; }
+
 set +u; [ -f .env ] && . .env; set -u
 SS_WORK="${SS_WORK:-/vol/work}"; SS_MODELS_DIR="${SS_MODELS_DIR:-/vol/models}"; SS_UVR_VENV="${SS_UVR_VENV:-/vol/venvs/uvr}"
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"; MODEL_DIR="$SS_MODELS_DIR/UVR"; MODEL="Reverb_HQ_By_FoxJoy.onnx"

--- a/scripts/40_rvc_convert.sh
+++ b/scripts/40_rvc_convert.sh
@@ -11,6 +11,13 @@ source "$SCRIPT_DIR/env.sh"
 
 : "${SS_UVR_VENV:=/vol/venvs/uvr}"; : "${SS_RVC_VENV:=/vol/venvs/rvc}"
 UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+
+usage(){ cat <<USAGE
+Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> <rvc.index> [v1|v2]
+USAGE
+}
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
+
 # requires $SS_UVR_VENV/bin/audio-separator and RVC CLI or module
 command -v "$UVR_BIN/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
 if [ -x "$RVC_BIN/rvc" ]; then
@@ -20,13 +27,6 @@ elif [ -x "$SS_RVC_VENV/bin/python" ]; then
 else
   echo "[ERR] rvc not found; run scripts/00_setup_env_split.sh"; exit 2;
 fi
-
-usage(){ cat <<USAGE
-Usage: scripts/40_rvc_convert.sh <slug> <rvc_pth> <rvc.index> [v1|v2]
-USAGE
-}
-[[ "${1:-}" =~ ^(-h|--help)$ ]] && usage && exit 0
-
 
 SLUG="$1"; RVC_PTH="$2"; RVC_INDEX="$3"; RVC_VER="${4:-v2}"
 BASE="$SS_WORK/${SLUG}"; OUTDIR="$SS_OUT/${SLUG}"; mkdir -p "$OUTDIR"


### PR DESCRIPTION
## Summary
- add `-h|--help` handling before environment validation in extractor and dereverb scripts
- move audio-separator check after help parsing in RVC conversion script

## Testing
- `bash scripts/20_extract_main.sh -h`
- `bash scripts/30_dereverb_denoise.sh -h`
- `bash scripts/40_rvc_convert.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_689ea09842c483308c90ed0d7b2c9474