### PR TITLE
feat: add dry-run and check options for gdrive scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ SS_PARALLEL_JOBS=4
 SS_RCLONE_TPS=4
 SS_RCLONE_CHECKERS=4
 SS_RCLONE_TRANSFERS=2
+SS_RCLONE_CHUNK=64M
 
 # --- rclone config path (uncomment to force) ---
 # RCLONE_CONFIG=/vol/rclone/rclone.conf


### PR DESCRIPTION
## Summary
- add SS_RCLONE_CHUNK to sample env and use it for drive chunk size
- support `--check` in gdrive_sync_models.sh to only validate model presence
- support `--dry-run` in gdrive_pull_inputs.sh and gdrive_push_outputs.sh, echoing rclone calls

## Testing
- `bash scripts/gdrive_pull_inputs.sh --dry-run` (fails: rclone command not found)
- `bash scripts/gdrive_push_outputs.sh --dry-run testslug` (fails: rclone command not found)
- `bash scripts/gdrive_sync_models.sh --check`
- `pre-commit run --files .env.example scripts/gdrive_pull_inputs.sh scripts/gdrive_push_outputs.sh scripts/gdrive_sync_models.sh` (fails: command not found)
- `pip install pre-commit` (fails: Tunnel connection failed: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689ea09a8dd8833094f7be0fce1d8fa7