### PR TITLE
feat: add preflight target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: help setup-lock setup-split setup sanity demo env one pull batch push backup doctor clean-cache index-first
+.PHONY: help setup-lock setup-split setup sanity demo env one pull batch push backup preflight doctor clean-cache index-first
 
 CHECK_VOL := if ! mountpoint -q /vol; then echo "[WARN] /vol not mounted. Attach Network Volume at /vol"; fi
 
@@ -17,6 +17,7 @@ help:
 > @echo "  push        - push processed outputs"
 > @echo "  backup      - backup outputs to gdrive"
 > @echo "  doctor      - space check"
+> @echo "  preflight   - run sanity and space checks"
 > @echo "  clean-cache - remove caches"
 > @echo "  index-first - build RVC index (make index-first wav=<in.wav> out=<out.index>)"
 
@@ -53,6 +54,10 @@ push:
 
 backup:
 > bash scripts/90_backup_gdrive.sh
+
+preflight:
+> bash scripts/sanity_check.sh || true
+> bash scripts/doctor_space.sh
 
 setup-split:
 > @if ! mountpoint -q /vol; then echo "[WARN] /vol not mounted. Attach Network Volume at /vol"; else bash scripts/00_setup_env_split.sh; fi

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Seperate02/
 * **Container Disk**：10–20 GiB
 * **Volume Disk**：≥100 GiB，挂载路径固定 `/vol`
 * `/workspace` 为容器根盘，重建后内容会丢失；`/vol` 为持久网络盘，模型和缓存应全部放在 `/vol`
+* 容器初始化后先运行 `make preflight` 检查环境与空间
 
 > **提示**：长命令可通过 `\` 分行，或使用 `tmux` 保持会话。
 
@@ -135,7 +136,7 @@ export RCLONE_CONFIG=/vol/rclone/rclone.conf
 
 ```bash
 # 0) 体检与空间
-make doctor    # 不足则 make clean-cache
+make preflight # 不足则 make clean-cache
 
 # 1) 安装到 /vol（双环境）
 make setup-split


### PR DESCRIPTION
## Summary
- add a `preflight` target combining environment and space checks
- document `make preflight` as the first step when starting a Runpod container

## Testing
- `make preflight`
- `pre-commit run --files Makefile README.md` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ea09eb0b0833089f2b83da6629b5f