### PR TITLE
Add wheelhouse caching and venv reuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,9 @@ SS_UVR_VENV=/vol/venvs/uvr
 SS_RVC_VENV=/vol/venvs/rvc
 
 # === 缓存/临时全部在 /vol ===
-SS_CACHE_DIR=/vol/.cache
 HF_HOME=/vol/.cache/hf
 TRANSFORMERS_CACHE=/vol/.cache/hf
 TORCH_HOME=/vol/.cache/torch
-PIP_CACHE_DIR=/vol/.cache/pip
 TMPDIR=/vol/tmp
 
 # RVC model paths
@@ -40,3 +38,17 @@ SS_RCLONE_CHUNK=64M
 SS_GDRIVE_REMOTE=gdrive
 # 顶层目录（脚本会自动在其下创建 inbox/out/logs 等）
 SS_GDRIVE_ROOT=Seperate02
+# === PIP 缓存（建议启用） ===
+SS_CACHE_DIR=/vol/.cache
+SS_PIP_CACHE=1                 # 1 启用 / 0 关闭
+# === CUDA & 轮子仓剖面（profile） ===
+SS_CUDA_TAG=cu124              # 与 requirements 中 torch/cu 版本一致
+SS_WHEELHOUSE=/vol/wheels
+# 形如：cp311-cu124-linux_x86_64；为空则脚本自动推断
+SS_WHEEL_PROFILE=
+# === GDrive 轮子仓远端位置 ===
+SS_WHEELS_REMOTE=${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/wheels
+# === 安装策略（强烈推荐开启） ===
+SS_PREFER_WHEELS=1             # 优先使用本地/远端轮子仓
+SS_WHEELS_PULL_ON_MISS=1       # 本地轮子缺失时自动从 GDrive 拉取
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: help setup-lock setup-split setup sanity demo env one pull batch push backup preflight doctor clean-cache index-first
+.PHONY: help setup-lock setup-split setup sanity demo env one pull batch push backup preflight doctor clean-cache index-first wheels-prepare wheels-pull wheels-push venv-clean
 
 CHECK_VOL := if ! mountpoint -q /vol; then echo "[WARN] /vol not mounted. Attach Network Volume at /vol"; fi
 
@@ -16,6 +16,10 @@ help:
 > @echo "  batch model=<pth> index=<idx> ver=<v1|v2>"
 > @echo "  push        - push processed outputs"
 > @echo "  backup      - backup outputs to gdrive"
+> @echo "  wheels-prepare - predownload wheels"
+> @echo "  wheels-pull    - pull wheels from gdrive"
+> @echo "  wheels-push    - push wheels to gdrive"
+> @echo "  venv-clean     - remove venvs"
 > @echo "  doctor      - space check"
 > @echo "  preflight   - run sanity and space checks"
 > @echo "  clean-cache - remove caches"
@@ -55,7 +59,22 @@ push:
 backup:
 > bash scripts/90_backup_gdrive.sh
 
+wheels-prepare:
+> @bash scripts/wheels_prepare.sh
+
+wheels-pull:
+> @bash scripts/wheels_pull.sh
+
+wheels-push:
+> @bash scripts/wheels_push.sh
+
+venv-clean:
+> @rm -rf /vol/venvs/uvr /vol/venvs/rvc
+
 preflight:
+> @mount | grep -E '[[:space:]]/vol[[:space:]]' || echo "[ERR] /vol 未挂载"
+> @df -h / /vol || true
+> @echo "RCLONE_CONFIG=$$RCLONE_CONFIG"; test -f "$$RCLONE_CONFIG" || echo "[WARN] RCLONE_CONFIG 未设置"
 > bash scripts/sanity_check.sh || true
 > bash scripts/doctor_space.sh
 

--- a/scripts/00_setup_env_split.sh
+++ b/scripts/00_setup_env_split.sh
@@ -19,6 +19,24 @@ USG
 : "${SS_RVC_VENV:=/vol/venvs/rvc}"
 : "${SS_CACHE_DIR:=/vol/.cache}"
 
+# === add near the top (pip cache, wheel vars, signature helpers) ===
+sig_lock_sha(){ sha256sum requirements-locked.txt 2>/dev/null | awk '{print $1}'; }
+mk_profile(){
+  python3 - <<'PY'
+import sys,platform,os
+cuda=os.environ.get("SS_CUDA_TAG","cu124")
+print(f"cp{sys.version_info.major}{sys.version_info.minor}-{cuda}-{platform.system().lower()}_{platform.machine()}")
+PY
+}
+PROFILE="${SS_WHEEL_PROFILE:-$(mk_profile)}"
+WHEELBASE="${SS_WHEELHOUSE:-/vol/wheels}/${PROFILE}"
+WH_UVR="${WHEELBASE}/uvr"; WH_RVC="${WHEELBASE}/rvc"; WH_LOCK="${WHEELBASE}/lock"
+
+if [[ "${SS_PIP_CACHE:-1}" -eq 1 ]]; then
+  export PIP_CACHE_DIR="${SS_CACHE_DIR:-/vol/.cache}/pip"
+  mkdir -p "$PIP_CACHE_DIR"
+fi
+
 ensure_vol_mount() {
   if ! mount | grep -Eq '[[:space:]]/vol[[:space:]]'; then
     echo "[ERR] /vol is not mounted. Please attach Network Volume at /vol in Runpod, then re-run." >&2
@@ -57,24 +75,84 @@ mkdir -p "$SS_UVR_VENV" "$SS_RVC_VENV" "$SS_CACHE_DIR"
 export HF_HOME="$SS_CACHE_DIR/hf"
 export TRANSFORMERS_CACHE="$SS_CACHE_DIR/hf"
 export TORCH_HOME="$SS_CACHE_DIR/torch"
-export PIP_CACHE_DIR="$SS_CACHE_DIR/pip"
 export TMPDIR=/vol/tmp
-mkdir -p "$HF_HOME" "$TORCH_HOME" "$PIP_CACHE_DIR" "$TMPDIR"
+mkdir -p "$HF_HOME" "$TORCH_HOME" "$TMPDIR"
 
-python3 -m venv "$SS_UVR_VENV"
-"$SS_UVR_VENV/bin/pip" install -U pip wheel setuptools
-"$SS_UVR_VENV/bin/pip" install --no-cache-dir -r requirements-uvr.txt
+write_sig(){
+  local venv="$1"
+  local sig="${venv}/.sig"
+  {
+    echo "profile=$PROFILE"
+    echo "py=$("$venv/bin/python" -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    echo "lock_sha=$(sig_lock_sha)"
+    date -u +"utc=%Y-%m-%dT%H:%M:%SZ"
+  } > "$sig"
+}
 
-python3 -m venv "$SS_RVC_VENV"
-"$SS_RVC_VENV/bin/python" -m pip install -U "pip<24.1" "setuptools<70" wheel
-"$SS_RVC_VENV/bin/pip" install --no-cache-dir "numpy==1.23.5"
-"$SS_RVC_VENV/bin/pip" install --no-cache-dir \
-  --index-url https://download.pytorch.org/whl/cu124 \
-  torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0
-"$SS_RVC_VENV/bin/pip" install --no-cache-dir -r requirements-rvc.txt
+need_rebuild(){
+  local venv="$1"; local sig="${venv}/.sig"
+  [[ -d "$venv" && -f "$sig" ]] || return 0
+  grep -q "profile=$PROFILE" "$sig" || return 0
+  if [[ -f requirements-locked.txt ]]; then
+    local cur=$(sig_lock_sha); grep -q "lock_sha=$cur" "$sig" || return 0
+  fi
+  return 1  # no rebuild needed
+}
 
-"$SS_UVR_VENV/bin/pip" cache purge || true
-"$SS_RVC_VENV/bin/pip" cache purge || true
+install_with_fallback(){
+  local VENV_BIN="$1"; shift
+  local REQ_FILE="$1"; shift
+  local WH_DIRS=("$@")
+
+  # 1) wheelhouse 优先
+  local FL=()
+  for d in "${WH_DIRS[@]}"; do [[ -d "$d" ]] && FL+=( --find-links "$d" ); done
+  if (( ${#FL[@]} )); then
+    if "$VENV_BIN/pip" install --no-index "${FL[@]}" -r "$REQ_FILE"; then
+      return 0
+    fi
+  fi
+
+  # 2) 自动从 GDrive 拉取再尝试
+  if [[ "${SS_PREFER_WHEELS:-1}" -eq 1 && "${SS_WHEELS_PULL_ON_MISS:-1}" -eq 1 ]]; then
+    bash scripts/wheels_pull.sh || true
+    FL=()
+    for d in "${WH_DIRS[@]}"; do [[ -d "$d" ]] && FL+=( --find-links "$d" ); done
+    if (( ${#FL[@]} )); then
+      if "$VENV_BIN/pip" install --no-index "${FL[@]}" -r "$REQ_FILE"; then
+        return 0
+      fi
+    fi
+  fi
+
+  # 3) 回源（带缓存）
+  "$VENV_BIN/pip" install -r "$REQ_FILE"
+}
+
+# ====== UVR venv ======
+if need_rebuild "$SS_UVR_VENV"; then
+  python3 -m venv "$SS_UVR_VENV"
+  "$SS_UVR_VENV/bin/pip" install -U pip wheel setuptools
+  install_with_fallback "$SS_UVR_VENV/bin" requirements-uvr.txt "$WH_UVR"
+  "$SS_UVR_VENV/bin/pip" cache purge || true
+  write_sig "$SS_UVR_VENV"
+else
+  echo "[OK] reuse UVR venv ($SS_UVR_VENV)"
+fi
+
+# ====== RVC venv ======
+if need_rebuild "$SS_RVC_VENV"; then
+  "$SS_RVC_VENV/bin/python" -m venv "$SS_RVC_VENV" || python3 -m venv "$SS_RVC_VENV"
+  "$SS_RVC_VENV/bin/python" -m pip install -U "pip<24.1" "setuptools<70" wheel
+  "$SS_RVC_VENV/bin/pip" install "numpy==1.23.5"
+  "$SS_RVC_VENV/bin/pip" install --index-url https://download.pytorch.org/whl/${SS_CUDA_TAG:-cu124} \
+    torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0
+  install_with_fallback "$SS_RVC_VENV/bin" requirements-rvc.txt "$WH_RVC"
+  "$SS_RVC_VENV/bin/pip" cache purge || true
+  write_sig "$SS_RVC_VENV"
+else
+  echo "[OK] reuse RVC venv ($SS_RVC_VENV)"
+fi
 
 UVR_BIN="$SS_UVR_VENV/bin/audio-separator"
 RVC_BIN="$SS_RVC_VENV/bin/rvc"

--- a/scripts/wheels_prepare.sh
+++ b/scripts/wheels_prepare.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# ---------- helpers ----------
+die(){ echo "[ERR] $*" >&2; exit 2; }
+env_or(){ local v="${!1:-}"; [[ -n "$v" ]] && echo "$v" || echo "$2"; }
+
+# ---------- profile ----------
+PYTAG=$(python3 - <<'PY'
+import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")
+PY
+)
+UNAME="$(uname -s | tr A-Z a-z)_$(uname -m)"
+PROFILE="${SS_WHEEL_PROFILE:-${PYTAG}-${SS_CUDA_TAG:-cu124}-${UNAME}}"
+
+BASE="${SS_WHEELHOUSE:-/vol/wheels}/${PROFILE}"
+WH_UVR="${BASE}/uvr"
+WH_RVC="${BASE}/rvc"
+WH_LOCK="${BASE}/lock"
+
+mkdir -p "$WH_UVR" "$WH_RVC" "$WH_LOCK"
+
+# ---------- venv sanity (we just need pip, so allow system pip fallback) ----------
+UVR_PIP="${SS_UVR_VENV:-/vol/venvs/uvr}/bin/pip"
+RVC_PIP="${SS_RVC_VENV:-/vol/venvs/rvc}/bin/pip"
+command -v "$UVR_PIP" >/dev/null 2>&1 || UVR_PIP="pip"
+command -v "$RVC_PIP" >/dev/null 2>&1 || RVC_PIP="pip"
+
+echo "[INF] PROFILE=$PROFILE"
+echo "[INF] wheelhouse=$BASE"
+
+# ---------- download ----------
+set -x
+"$UVR_PIP" download -r requirements-uvr.txt -d "$WH_UVR"
+"$RVC_PIP" download -r requirements-rvc.txt -d "$WH_RVC"
+if [[ -f requirements-locked.txt ]]; then
+  "$UVR_PIP" download -r requirements-locked.txt -d "$WH_LOCK" || true
+fi
+set +x
+
+echo "[OK] wheels prepared under $BASE"

--- a/scripts/wheels_pull.sh
+++ b/scripts/wheels_pull.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+PROFILE="${SS_WHEEL_PROFILE:-$(python3 - <<'PY'
+import sys,platform
+print(f"cp{sys.version_info.major}{sys.version_info.minor}-" +
+      f"{__import__('os').environ.get('SS_CUDA_TAG','cu124')}-" +
+      f"{platform.system().lower()}_{platform.machine()}")
+PY
+)}"
+BASE="${SS_WHEELHOUSE:-/vol/wheels}/${PROFILE}"
+REMOTE="${SS_WHEELS_REMOTE:?missing SS_WHEELS_REMOTE}/${PROFILE}"
+mkdir -p "$BASE"
+
+set +e
+rclone lsd "$REMOTE" >/dev/null 2>&1
+has_remote=$?
+set -e
+if [[ $has_remote -ne 0 ]]; then
+  echo "[WARN] remote wheelhouse not found: $REMOTE"
+  exit 0
+fi
+
+rclone copy "$REMOTE" "$BASE" --checksum --fast-list \
+  --transfers "${SS_RCLONE_TRANSFERS:-4}" --checkers "${SS_RCLONE_CHECKERS:-8}" \
+  --drive-chunk-size "${SS_RCLONE_CHUNK:-64M}"
+echo "[OK] pulled $REMOTE -> $BASE"

--- a/scripts/wheels_push.sh
+++ b/scripts/wheels_push.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+PROFILE="${SS_WHEEL_PROFILE:-$(python3 - <<'PY'
+import sys,platform
+print(f"cp{sys.version_info.major}{sys.version_info.minor}-" +
+      f"{__import__('os').environ.get('SS_CUDA_TAG','cu124')}-" +
+      f"{platform.system().lower()}_{platform.machine()}")
+PY
+)}"
+BASE="${SS_WHEELHOUSE:-/vol/wheels}/${PROFILE}"
+REMOTE="${SS_WHEELS_REMOTE:?missing SS_WHEELS_REMOTE}/${PROFILE}"
+
+[[ -d "$BASE" ]] || { echo "[ERR] local wheelhouse missing: $BASE"; exit 2; }
+rclone copy "$BASE" "$REMOTE" --checksum --fast-list \
+  --transfers "${SS_RCLONE_TRANSFERS:-4}" --checkers "${SS_RCLONE_CHECKERS:-8}" \
+  --drive-chunk-size "${SS_RCLONE_CHUNK:-64M}"
+echo "[OK] pushed $BASE -> $REMOTE"


### PR DESCRIPTION
## Summary
- cache wheels locally and in GDrive with helper scripts
- reuse venvs when signatures match and favor wheelhouse installs
- expose wheel cache controls in sample env and Makefile

## Testing
- `pre-commit run --files .env.example Makefile scripts/00_setup_env_split.sh scripts/wheels_prepare.sh scripts/wheels_push.sh scripts/wheels_pull.sh` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_689f2b2c02948330af53dc7157d4ee27