### PR TITLE
Add quality guardrails and fix wheel scripts

### DIFF
--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -2,11 +2,6 @@
 set -euo pipefail
 export LC_ALL=C.UTF-8
 
-: "${SS_UVR_VENV:=/vol/venvs/uvr}"; : "${SS_RVC_VENV:=/vol/venvs/rvc}"
-UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
-# requires $SS_UVR_VENV/bin/audio-separator and $SS_RVC_VENV/bin/rvc
-command -v "$UVR_BIN/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
-
 usage(){
   cat <<'USAGE'
 Usage: scripts/run_batch.sh <rvc_model.pth> <rvc.index> [v1|v2]
@@ -14,6 +9,14 @@ Desc : 基于 $SS_WORK/*/.lock 队列并发处理多首歌，每首日志写入 
 Env  : SS_WORK, SS_PARALLEL_JOBS
 USAGE
 }
+
+case "${1:-}" in -h|--help) usage; exit 0;; esac
+
+: "${SS_UVR_VENV:=/vol/venvs/uvr}"; : "${SS_RVC_VENV:=/vol/venvs/rvc}"
+UVR_BIN="$SS_UVR_VENV/bin"; RVC_BIN="$SS_RVC_VENV/bin"
+# requires $SS_UVR_VENV/bin/audio-separator and $SS_RVC_VENV/bin/rvc
+command -v "$UVR_BIN/audio-separator" >/dev/null || { echo "[ERR] audio-separator not found; run scripts/00_setup_env_split.sh"; exit 2; }
+
 ensure_vol_mount() {
   if ! mount | grep -Eq '[[:space:]]/vol[[:space:]]'; then
     echo "[ERR] /vol is not mounted. Please attach Network Volume at /vol in Runpod, then re-run." >&2
@@ -22,7 +25,6 @@ ensure_vol_mount() {
   fi
 }
 
-case "${1:-}" in -h|--help) usage; exit 0;; esac
 ensure_vol_mount
 [[ -n "${1:-}" && -n "${2:-}" ]] || { usage; exit 2; }
 

--- a/scripts/wheels_pull.sh
+++ b/scripts/wheels_pull.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+export RCLONE_CONFIG="${RCLONE_CONFIG:-/vol/rclone/rclone.conf}"
 PROFILE="${SS_WHEEL_PROFILE:-$(python3 - <<'PY'
 import sys,platform
 print(f"cp{sys.version_info.major}{sys.version_info.minor}-" +
@@ -12,7 +13,7 @@ REMOTE="${SS_WHEELS_REMOTE:?missing SS_WHEELS_REMOTE}/${PROFILE}"
 mkdir -p "$BASE"
 
 set +e
-rclone lsd "$REMOTE" >/dev/null 2>&1
+rclone lsd "$REMOTE" >/dev/null 2>/dev/null
 has_remote=$?
 set -e
 if [[ $has_remote -ne 0 ]]; then

--- a/scripts/wheels_push.sh
+++ b/scripts/wheels_push.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+export RCLONE_CONFIG="${RCLONE_CONFIG:-/vol/rclone/rclone.conf}"
 PROFILE="${SS_WHEEL_PROFILE:-$(python3 - <<'PY'
 import sys,platform
 print(f"cp{sys.version_info.major}{sys.version_info.minor}-" +


### PR DESCRIPTION
## Summary
- enforce LUFS/peak/drift checks in finalize script and wrap entry point with `sys.exit`
- export `RCLONE_CONFIG` and fix rclone check/redirection in wheel scripts
- ensure run_batch `-h` exits cleanly with usage

## Testing
- `pre-commit run --files scripts/50_finalize_and_report.py scripts/wheels_pull.sh scripts/wheels_push.sh scripts/run_batch.sh` *(fails: pre-commit: command not found)*
- `rg -n 'sys\.exit\(main\(\)\)' scripts/50_finalize_and_report.py || grep -n 'sys\.exit(main())' scripts/50_finalize_and_report.py`
- `grep -nE 'TARGET_LUFS_|PEAK_CEIL|OUT_SR|drift|quality_report\.json' scripts/50_finalize_and_report.py`
- `sed -n '1,80p' scripts/wheels_prepare.sh | sed -n '1,40p'`
- `sed -n '1,80p' scripts/wheels_pull.sh | sed -n '1,40p'`
- `sed -n '1,80p' scripts/wheels_push.sh | sed -n '1,40p'`
- `bash scripts/run_batch.sh -h >/dev/null 2>&1; echo "run_batch_help_exit=$?"`
- `grep -nE -- '-ac[= ]2| -ar[= ]48000|pcm_s16le' scripts/20_extract_main.sh || sed -n '1,120p' scripts/20_extract_main.sh`
- `nl -ba Makefile | sed -n '24,38p'`


------
https://chatgpt.com/codex/tasks/task_e_689f79d839ec833093094b7d91cef222