### PR TITLE
Guard against zero-duration outputs and harden GDrive push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ TMPDIR=/vol/tmp
 SS_RVC_PTH=/vol/models/RVC/G_8200.pth
 SS_RVC_INDEX=/vol/models/RVC/G_8200.index
 SS_RVC_VER=v2
+SS_UVR_USE_SOUNDFILE=1
 
 # Parallel jobs for batch processing
 SS_PARALLEL_JOBS=4

--- a/scripts/10_separate_inst.sh
+++ b/scripts/10_separate_inst.sh
@@ -7,7 +7,7 @@ Desc : Step-10 UVR 分离伴奏与主唱，产出 01_accompaniment.wav / 01_voca
 Opts : --use-soundfile  使用 soundfile 写盘（也可用 SS_UVR_USE_SOUNDFILE=1）
 USG
 }
-USE_SF=${SS_UVR_USE_SOUNDFILE:-0}
+USE_SF=${SS_UVR_USE_SOUNDFILE:-1}
 case "${1:-}" in -h|--help) usage; exit 0;; --use-soundfile) USE_SF=1; shift;; esac
 IN=${1:-}; SLUG=${2:-}; [[ -f "${IN:-}" && -n "${SLUG:-}" ]] || { usage; exit 2; }
 set +u; [ -f .env ] && . .env; set -u
@@ -23,4 +23,19 @@ inst=( "$WORK_DIR"/*"(Instrumental)"*UVR-MDX-NET-Inst_HQ_3.wav ); voc=( "$WORK_D
 [[ ${#inst[@]} -ge 1 ]] || { echo "[ERR] Instrumental stem not found"; exit 3; }
 [[ ${#voc[@]}  -ge 1 ]] || { echo "[ERR] Vocals stem not found"; exit 3; }
 mv -f "${inst[0]}" "$WORK_DIR/01_accompaniment.wav"; mv -f "${voc[0]}"  "$WORK_DIR/01_vocals_mix.wav"
+dur(){ ffprobe -v error -select_streams a:0 -show_entries stream=duration -of default=nk=1:nw=1 "$1" 2>/dev/null || echo 0; }
+fix_if_zero(){
+  local want="$1" src="$2"
+  local d; d=$(dur "$want")
+  if awk "BEGIN{exit !($d>0)}"; then
+    echo "[OK] $(basename "$want") duration=$d"
+  else
+    echo "[WARN] zero duration: $(basename "$want"); rewriting via ffmpeg"
+    ffmpeg -y -v error -i "$src" -ac 2 -ar 48000 -c:a pcm_s16le "$want"
+    d=$(dur "$want"); awk "BEGIN{exit !($d>0)}" || { echo "[FATAL] still zero after rewrite"; exit 4; }
+    echo "[OK] rewrite fixed: $(basename "$want") duration=$d"
+  fi
+}
+fix_if_zero "$WORK_DIR/01_vocals_mix.wav" "${voc[0]}"
+fix_if_zero "$WORK_DIR/01_accompaniment.wav" "${inst[0]}"
 echo "[OK] 10 -> 01_accompaniment.wav, 01_vocals_mix.wav"

--- a/scripts/wheels_pull.sh
+++ b/scripts/wheels_pull.sh
@@ -13,7 +13,7 @@ REMOTE="${SS_WHEELS_REMOTE:?missing SS_WHEELS_REMOTE}/${PROFILE}"
 mkdir -p "$BASE"
 
 set +e
-rclone lsd "$REMOTE" >/dev/null 2>/dev/null
+rclone lsd "$REMOTE" >/dev/null 2>&1
 has_remote=$?
 set -e
 if [[ $has_remote -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Default UVR separation to use soundfile and add duration checks with ffmpeg rewrite fallback
- Skip GDrive push when local output is missing and pre-create remote folders
- Fix wheel pull script logging by redirecting stderr correctly and exporting config
- Expose `SS_UVR_USE_SOUNDFILE` in example env for stability

## Testing
- `bash -n scripts/10_separate_inst.sh scripts/gdrive_push_outputs.sh scripts/wheels_pull.sh`
- `pre-commit run --files .env.example scripts/10_separate_inst.sh scripts/gdrive_push_outputs.sh scripts/wheels_pull.sh` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `shellcheck scripts/10_separate_inst.sh scripts/gdrive_push_outputs.sh scripts/wheels_pull.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f94e4ae1483309f8ceb5b0777c821