### PR TITLE
feat: add Snakemake integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,8 @@ jobs:
             || echo "markdownlint found issues (non-blocking)"
       - name: Bash syntax check
         run: bash -n scripts/*.sh
+      - name: Snakemake dry-run (non-blocking)
+        continue-on-error: true
+        run: |
+          pipx install "snakemake>=9,<10" || pip install "snakemake>=9,<10"
+          snakemake -s Snakefile --cores 1 -n || echo "snakemake dry-run skipped"

--- a/Makefile
+++ b/Makefile
@@ -97,3 +97,13 @@ clean-cache:
 index-first:
 > @echo "Use scripts/70_build_index_from_wav.py to build index:"
 > @echo "  ${SS_RVC_VENV:-/vol/venvs/rvc}/bin/python scripts/70_build_index_from_wav.py --wav <in.wav> --out <out.index>"
+
+# --- Snakemake integration ---
+snk-dry:
+> snakemake -s Snakefile --cores 1 -n
+
+snk-run:
+> snakemake -s Snakefile --profile profiles/runpod
+
+snk-run-slug:
+> snakemake -s Snakefile --profile profiles/runpod --config slug=$(slug)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [并发与吞吐策略](#并发与吞吐策略)
 - [失败恢复与可复现](#失败恢复与可复现)
 - [Roadmap](#roadmap)
+- [Snakemake 参考资料](#snakemake-参考资料)
 - [FAQ](#faq)
 - [许可与第三方声明](#许可与第三方声明)
 
@@ -411,6 +412,17 @@ python -m stepflow.cli.ssflow --manifest examples/demo.yaml
 - [ ] Docker 镜像（锁定 CUDA/ORT/Python 版本）
 - [ ] CI：仅做 lint/构建，不跑模型（避免泄露与不稳定）
 - [ ] 指标采集：批处理成功率、耗时分布、显存峰值（写入 trace）
+
+---
+
+## Snakemake 参考资料
+
+- 官网：[Snakemake](https://snakemake.github.io)
+- 文档首页：[Snakemake 9.x Docs](https://snakemake.readthedocs.io/en/stable/)
+- 安装指南：[Installation](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html)
+- CLI 参考：[Command Line Interface](https://snakemake.readthedocs.io/en/stable/executing/cli.html)
+- 源码仓库：[GitHub - snakemake/snakemake](https://github.com/snakemake/snakemake)
+- Profiles 生态：[Snakemake Profiles](https://snakemake.readthedocs.io/en/stable/executing/profile.html)
 
 ---
 

--- a/Snakefile
+++ b/Snakefile
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import os
+
+# 配置优先顺序：命令行 --config > config/config.yaml > 环境变量/默认值
+configfile: "config/config.yaml" if os.path.exists("config/config.yaml") else None
+
+SS_WORK  = config.get("SS_WORK",  os.getenv("SS_WORK",  "/vol/work"))
+SS_OUT   = config.get("SS_OUT",   os.getenv("SS_OUT",   "/vol/out"))
+RVC_PTH  = config.get("rvc_pth",  os.getenv("SS_RVC_PTH",  "/vol/models/RVC/G_8200.pth"))
+RVC_IDX  = config.get("rvc_index",os.getenv("SS_RVC_INDEX","/vol/models/RVC/G_8200.index"))
+RVC_VER  = config.get("rvc_ver",  os.getenv("SS_RVC_VER",  "v2"))
+SLUG     = config.get("slug", None)
+
+if SLUG is None:
+    raise ValueError("Missing required config: slug (可用 --config slug=... 传入；或在 config/config.yaml 中配置)")
+
+rule all:
+    input:
+        f"{SS_OUT}/{SLUG}/quality_report.json"
+
+rule end_to_end:
+    output:
+        f"{SS_OUT}/{SLUG}/quality_report.json"
+    shell:
+        r"""
+        # 说明：依赖现有 run_one.sh 串行执行 10/20/30/40/50 并生成 quality_report.json
+        # run_one.sh 支持传入 slug（需要 .src 已存在），或直接传入音频路径。
+        # 这里我们约定 slug 模式（更稳健）；请先用 gdrive_pull_inputs.sh 将歌曲拉到 /vol 并生成 .src。
+        bash scripts/run_one.sh "{SLUG}" "{RVC_PTH}" "{RVC_IDX}" "{RVC_VER}"
+
+        test -f "{SS_OUT}/{SLUG}/quality_report.json" || {{
+          echo "[ERR] missing quality_report.json for slug={SLUG}" >&2; exit 3;
+        }}
+        """
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,12 @@
+# 运行时基础路径（Runpod /vol 约定）
+SS_WORK: /vol/work
+SS_OUT: /vol/out
+
+# RVC 模型默认值（可在命令行 --config 覆盖）
+rvc_pth: /vol/models/RVC/G_8200.pth
+rvc_index: /vol/models/RVC/G_8200.index
+rvc_ver: v2
+
+# 必填：处理哪个 slug（由 gdrive_pull_inputs.sh 生成）
+# slug: your_slug_here
+

--- a/profiles/runpod/config.yaml
+++ b/profiles/runpod/config.yaml
@@ -1,0 +1,12 @@
+printshellcmds: true
+keep-going: true
+rerun-incomplete: true
+latency-wait: 30
+restart-times: 0
+cores: 1
+use-conda: false
+# 可选：详细日志
+show-failed-logs: true
+# DAG/报告类（需要时手动开启）
+# report: true
+


### PR DESCRIPTION
## Summary
- add Snakemake V1 pipeline invoking existing run_one.sh
- provide default config and runpod profile
- document Snakemake resources and wiring

## Testing
- `pip install "snakemake>=9,<10"` *(failed: Could not connect to proxy)*
- `snakemake -s Snakefile --cores 1 -n --config slug=dummy` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb6414f4c8330b77c66a70c4a434b