### PR TITLE
Fix GDrive root handling and improve setup checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,10 +34,15 @@ SS_RCLONE_CHUNK=64M
 
 
 # --- Google Drive ---
+# 推荐在 rclone.conf 中设置 root_folder_id 指向 Seperate02 目录
+# SS_GDRIVE_ROOT 三态：
+#   （未设置） -> 默认 "Seperate02"（兼容旧用法）
+#   "" 或 "."  -> 使用 root_folder_id（或账号根）
+#   其它字符串 -> 使用该子目录
+# 建议：留空（用 root_folder_id）
+# SS_GDRIVE_ROOT=
 # rclone 远端名（`rclone config` 创建后得到的名称）
 SS_GDRIVE_REMOTE=gdrive
-# 顶层目录（脚本会自动在其下创建 inbox/out/logs 等）
-SS_GDRIVE_ROOT=Seperate02
 # === PIP 缓存（建议启用） ===
 SS_CACHE_DIR=/vol/.cache
 SS_PIP_CACHE=1                 # 1 启用 / 0 关闭

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ preflight:
 > @df -h / /vol || true
 > @echo "RCLONE_CONFIG=$$RCLONE_CONFIG"; test -f "$$RCLONE_CONFIG" || echo "[WARN] RCLONE_CONFIG 未设置"
 > bash scripts/sanity_check.sh || true
-> bash scripts/doctor_space.sh
+> bash scripts/doctor_space.sh || true
 
 setup-split:
 > @if ! mountpoint -q /vol; then echo "[WARN] /vol not mounted. Attach Network Volume at /vol"; else bash scripts/00_setup_env_split.sh; fi
@@ -118,6 +118,9 @@ lock-refresh:
 > pip-compile --generate-hashes -o requirements-locked.txt requirements-uvr.txt requirements-rvc.txt
 
 uv-setup:
+> if ! command -v uv >/dev/null 2>&1; then \
+>   echo "[ERR] uv not found. Set SS_USE_UV=0 or install uv first (https://github.com/astral-sh/uv)."; exit 2; \
+> fi
 > uv venv /vol/venvs/uvr
 > . /vol/venvs/uvr/bin/activate && uv pip install -r requirements-locked.txt
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -13,5 +13,10 @@ SS_OUT=${SS_OUT:-/vol/out}
 SS_MODELS_DIR=${SS_MODELS_DIR:-/vol/models}
 SS_ASSETS_DIR=${SS_ASSETS_DIR:-/vol/assets}
 SS_GDRIVE_REMOTE=${SS_GDRIVE_REMOTE:-gdrive}
-SS_GDRIVE_ROOT=${SS_GDRIVE_ROOT:-Seperate02}
+if [ -z "${SS_GDRIVE_ROOT+x}" ]; then
+  export SS_GDRIVE_ROOT="Seperate02"
+fi
+if [ -z "${SS_USE_UV+x}" ]; then
+  export SS_USE_UV=0
+fi
 SS_PARALLEL_JOBS=${SS_PARALLEL_JOBS:-4}

--- a/scripts/gdrive_push_outputs.sh
+++ b/scripts/gdrive_push_outputs.sh
@@ -35,7 +35,13 @@ slug="$1"
 SS_OUT=${SS_OUT:-/vol/out}
 SS_WORK=${SS_WORK:-/vol/work}
 SS_GDRIVE_REMOTE=${SS_GDRIVE_REMOTE:-gdrive}
-SS_GDRIVE_ROOT=${SS_GDRIVE_ROOT:-Seperate02}
+if [ -z "${SS_GDRIVE_ROOT+x}" ]; then
+  SS_GDRIVE_ROOT="Seperate02"
+fi
+_root="$SS_GDRIVE_ROOT"
+[ "$_root" = "." ] && _root=""
+REMOTE_PREFIX="${SS_GDRIVE_REMOTE}:${_root:+${_root}/}"
+echo "[DBG] REMOTE_PREFIX=${REMOTE_PREFIX}" >&2
 workdir="$SS_WORK/$slug"; srcf="$workdir/.src"
 [[ -f "$srcf" ]] || { echo "[ERR] missing $srcf" >&2; exit 1; }
 
@@ -50,18 +56,18 @@ if [[ ! -d "$outdir" ]]; then
   exit 0
 fi
 
-REMOTE_BASE="$SS_GDRIVE_REMOTE:$SS_GDRIVE_ROOT"
+REMOTE_BASE="$REMOTE_PREFIX"
 # ensure remote folders exist (avoid 404)
 rclone mkdir "$REMOTE_BASE" || true
-rclone mkdir "$REMOTE_BASE/out" || true
-rclone mkdir "$REMOTE_BASE/processed" || true
-rclone mkdir "$REMOTE_BASE/failed" || true
+rclone mkdir "${REMOTE_BASE}out" || true
+rclone mkdir "${REMOTE_BASE}processed" || true
+rclone mkdir "${REMOTE_BASE}failed" || true
 
 # 上传最终产物
 RCLONE_GLOBAL=(--tpslimit "${SS_RCLONE_TPS:-4}" --tpslimit-burst "${SS_RCLONE_TPS:-4}" --checkers "${SS_RCLONE_CHECKERS:-4}" --transfers "${SS_RCLONE_TRANSFERS:-2}" --fast-list --drive-chunk-size "${SS_RCLONE_CHUNK:-64M}")
 $DRY_RUN && RCLONE_GLOBAL+=(--dry-run)
 rclone_cmd(){ echo "+ rclone ${RCLONE_GLOBAL[*]} $*" >&2; rclone "${RCLONE_GLOBAL[@]}" "$@"; }
-rclone_cmd copy "$outdir" "$REMOTE_BASE/out/$slug" --checksum
+rclone_cmd copy "$outdir" "${REMOTE_BASE}out/$slug" --checksum
 
 # 判定成功/失败
 pass=false
@@ -71,18 +77,18 @@ fi
 
 if $pass; then
   # 移动原始文件到 processed
-  rclone_cmd moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/processed/${fname}" || true
+  rclone_cmd moveto "$remote_path" "${REMOTE_PREFIX}inbox/processed/${fname}" || true
   # 上传 per‑song run.log
   LOG_LOCAL="$SS_WORK/$slug/run.log"
   if [[ -f "$LOG_LOCAL" ]]; then
     TS=$(date -u +%Y%m%d)
-    rclone_cmd copyto "$LOG_LOCAL" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/logs/${TS}/${slug}_run.log" --checksum || true
+    rclone_cmd copyto "$LOG_LOCAL" "${REMOTE_PREFIX}logs/${TS}/${slug}_run.log" --checksum || true
   fi
   # 清理工作目录（成功后）
   rm -rf "$SS_WORK/$slug" || true
 else
   # 失败：移动到 failed 并写原因
-  rclone_cmd moveto "$remote_path" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}" || true
+  rclone_cmd moveto "$remote_path" "${REMOTE_PREFIX}inbox/failed/${fname}" || true
   reason_file="/tmp/${slug}.reason.txt"
   echo "Seperate02 failure for $slug" > "$reason_file"
   [[ -f "$outdir/quality_report.json" ]] && {
@@ -94,7 +100,7 @@ else
     echo -e "\n--- run.log (tail -n 200) ---" >> "$reason_file"
     tail -n 200 "$SS_WORK/$slug/run.log" >> "$reason_file" || true
   fi
-  rclone_cmd copyto "$reason_file" "${SS_GDRIVE_REMOTE}:${SS_GDRIVE_ROOT}/inbox/failed/${fname}.reason.txt"
+  rclone_cmd copyto "$reason_file" "${REMOTE_PREFIX}inbox/failed/${fname}.reason.txt"
   rm -f "$reason_file"
 fi
 


### PR DESCRIPTION
## Summary
- Honor three-state GDrive root and add REMOTE_PREFIX helper across scripts
- Quiet false SIGPIPE errors and guard uv setup
- Relax sanity checks and clarify env example

## Testing
- `unset SS_GDRIVE_ROOT; source scripts/env.sh; echo "$SS_GDRIVE_ROOT"`
- `SS_GDRIVE_ROOT=; source scripts/env.sh; echo ">$SS_GDRIVE_ROOT<"`
- `SS_GDRIVE_ROOT=.; source scripts/env.sh; echo "$SS_GDRIVE_ROOT"`
- `rg -n 'GDRIVE_ROOT.*songs|gdrive:.*songs' scripts | grep -v REMOTE_PREFIX || echo OK`
- `SS_GDRIVE_ROOT=  bash -x scripts/gdrive_pull_inputs.sh --dry-run 2>&1 | sed -n '1,40p' | grep -E 'REMOTE_PREFIX|lsf'`
- `SS_GDRIVE_ROOT=. bash -x scripts/gdrive_pull_inputs.sh --dry-run 2>&1 | sed -n '1,40p' | grep -E 'REMOTE_PREFIX|lsf'`
- `SS_GDRIVE_ROOT=Seperate02 bash -x scripts/gdrive_pull_inputs.sh --dry-run 2>&1 | sed -n '1,40p' | grep -E 'REMOTE_PREFIX|lsf'`
- `bash -x scripts/gdrive_sync_models.sh --check 2>&1 | sed -n '1,80p'`
- `bash -x scripts/gdrive_push_outputs.sh --dry-run foo 2>&1 | sed -n '1,40p'`
- `SHELL=bash make preflight 2>&1 | tail -n 20`
- `bash scripts/sanity_check.sh 2>&1 | head -n 40`
- `bash scripts/sanity_check.sh 2>&1 | tail -n 20`
- `rg -n 'pip install shfmt' || echo 'no-pip-shfmt'`


------
https://chatgpt.com/codex/tasks/task_e_689fe81e4a908330a8b588f791aec660